### PR TITLE
Add Python linting and tests

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -6,12 +6,18 @@ on:
   pull_request:
 
 jobs:
-  run-scripts:
+  lint-and-test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
           python-version: '3.13'
-      - name: Run scripts
-        run: python Scripts/hello.py
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install ruff pytest
+      - name: Lint
+        run: ruff check Scripts
+      - name: Test
+        run: pytest Scripts/tests

--- a/README.md
+++ b/README.md
@@ -17,4 +17,5 @@ Docs/           Additional documentation
 ```
 
 The goal is to experiment with on-device LLM inference and benchmarking on Apple silicon. The runtime uses Swift 6.1 and the scripts require Python 3.13. Continuous integration builds the iOS target and runs the Swift and Python tests on each pull request. The iOS workflow installs Swift 6.1 using [`swift-actions/setup-swift`](https://github.com/swift-actions/setup-swift) and invokes `xcodebuild` with `-toolchain "$TOOLCHAINS"` so the correct toolchain is used.
+Python scripts are linted with [Ruff](https://docs.astral.sh/ruff/) and tested using `pytest`.
 

--- a/Scripts/convert.py
+++ b/Scripts/convert.py
@@ -14,12 +14,12 @@ from __future__ import annotations
 import argparse
 from pathlib import Path
 
-import coremltools as ct
-from transformers import AutoModelForCausalLM, AutoTokenizer
-
 
 def convert_pytorch(model_id: str, output: Path, *, seq_length: int) -> None:
     """Convert a Hugging Face model to Core ML."""
+    import coremltools as ct
+    from transformers import AutoModelForCausalLM, AutoTokenizer
+
     model = AutoModelForCausalLM.from_pretrained(model_id)
     tokenizer = AutoTokenizer.from_pretrained(model_id)
     mlmodel = ct.converters.transformers.convert(

--- a/Scripts/tests/test_scripts.py
+++ b/Scripts/tests/test_scripts.py
@@ -1,0 +1,40 @@
+import subprocess
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import pytest
+
+
+def test_hello_script():
+    output = subprocess.check_output([
+        "python",
+        Path(__file__).resolve().parents[1] / "hello.py",
+    ])
+    assert output.decode().strip() == "Hello from Python scripts"
+
+
+def test_convert_main_gguf():
+    import Scripts.convert as convert
+
+    with pytest.raises(NotImplementedError):
+        convert.main(["dummy", "out.mlpackage", "--gguf"])
+
+
+def test_convert_main_pytorch(monkeypatch, tmp_path):
+    import Scripts.convert as convert
+
+    called = {}
+
+    def fake_convert(model_id: str, output: Path, *, seq_length: int) -> None:
+        called["args"] = (model_id, output, seq_length)
+
+    monkeypatch.setattr(convert, "convert_pytorch", fake_convert)
+    convert.main(["mymodel", str(tmp_path / "out.mlpackage"), "--seq-length", "16"])
+
+    assert called["args"] == (
+        "mymodel",
+        tmp_path / "out.mlpackage",
+        16,
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[tool.ruff]
+target-version = "py313"
+line-length = 88


### PR DESCRIPTION
## Summary
- add Ruff configuration and new Python test suite
- update convert.py to import heavy packages lazily
- update CI workflow to run ruff and pytest
- document Python linting in README

## Testing
- `ruff check Scripts`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687bae545cb4833297eb3065419f4b37