### PR TITLE
Implement CoreML backend skeleton

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -97,8 +97,8 @@ Embed **ggml** via Swift Package **SpeziLLM**.  This lets power users swap betwe
 - [ ] **Document conversion workflow** in `Docs/ConversionGuide.md`.
 
 
-### WS-2 RuntimeCoreML tasks
-- [ ] **Create `CoreMLBackend.swift`** – token loop using stateful model evaluation.
+-### WS-2 RuntimeCoreML tasks
+- [x] **Create `CoreMLBackend.swift`** – token loop using stateful model evaluation.
 - [ ] **Expose `TokenStreamDelegate`** – callback for each generated token.
 - [ ] **Implement KV cache tensors** with `MLShapedArray` and LRU paging.
 - [ ] **Provide rope & rotary table kernels** via `MPSGraph` fallback.

--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,12 @@ let package = Package(
     ],
     targets: [
         .target(
+            name: "RuntimeCoreML",
+            path: "Sources/Runtime/CoreML"
+        ),
+        .target(
             name: "Lilims",
+            dependencies: ["RuntimeCoreML"],
             path: "Sources/Lilims"
         ),
         .executableTarget(

--- a/Sources/Runtime/CoreML/CoreMLBackend.swift
+++ b/Sources/Runtime/CoreML/CoreMLBackend.swift
@@ -1,0 +1,55 @@
+// The Core ML backend is only built on platforms where CoreML is available.
+#if canImport(CoreML)
+import CoreML
+import Foundation
+
+/// Backend that runs language models using Core ML stateful evaluation.
+public final class CoreMLBackend {
+    private let model: MLModel
+    private var state: MLFeatureProvider?
+
+    /// Initializes the backend with a compiled Core ML model at *url*.
+    public init(modelAt url: URL) throws {
+        self.model = try MLModel(contentsOf: url)
+    }
+
+    /// Generates up to `maxTokens` continuations for the given `prompt`.
+    /// - Returns: The combined prompt and generated tokens.
+    public func generate(prompt: [Int32], maxTokens: Int) throws -> [Int32] {
+        var tokens = prompt
+        let options = MLPredictionOptions()
+        options.usesCPUOnly = false
+        for _ in 0..<maxTokens {
+            let input = try MLDictionaryFeatureProvider(dictionary: [
+                "token": MLFeatureValue(int32: tokens.last ?? 0)
+            ])
+            let combinedInput: MLFeatureProvider
+            if let state = state {
+                combinedInput = MLDictionaryFeatureProvider(from: input, merging: state)
+            } else {
+                combinedInput = input
+            }
+            let output = try model.prediction(from: combinedInput, options: options)
+            state = output
+            guard let next = output.featureValue(for: "token")?.int32Value else {
+                break
+            }
+            tokens.append(next)
+        }
+        return tokens
+    }
+}
+
+private extension MLDictionaryFeatureProvider {
+    convenience init(from a: MLFeatureProvider, merging b: MLFeatureProvider) throws {
+        var dict: [String: MLFeatureValue] = [:]
+        for feature in a.featureNames {
+            dict[feature] = a.featureValue(for: feature)
+        }
+        for feature in b.featureNames {
+            dict[feature] = b.featureValue(for: feature)
+        }
+        try self.init(dictionary: dict)
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- mark the first WS-2 task as complete
- create `CoreMLBackend.swift` for stateful token generation
- add new RuntimeCoreML target and link it to the main library

## Testing
- `swift test -l`
- `ruff check Scripts`
- `pytest Scripts/tests -q`


------
https://chatgpt.com/codex/tasks/task_b_687bc06a42508332827fb54ff977368d