### PR TITLE
Enhance manifest generator with semantic versioning support

### DIFF
--- a/Docs/REVIEW_ACTION_PLAN.md
+++ b/Docs/REVIEW_ACTION_PLAN.md
@@ -25,9 +25,9 @@
 - [x] Add model architecture detection (GPT-2, Phi-2, Gemma)
 
 ### Task 1.2: Create manifest generator
-- [ ] Implement `Scripts/manifest.py` to generate model metadata
-- [ ] Include model name, size, SHA256, runtime version
-- [ ] Add semantic versioning support
+- [x] Implement `Scripts/manifest.py` to generate model metadata
+- [x] Include model name, size, SHA256, runtime version
+- [x] Add semantic versioning support
 
 ### Task 1.3: Fix GGUF conversion
 - [ ] Parse GGUF model architecture properly

--- a/Scripts/manifest.py
+++ b/Scripts/manifest.py
@@ -5,38 +5,91 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import re
+from datetime import datetime
 from pathlib import Path
 
 
-def generate_manifest(model_path: Path, runtime_version: str, *, name: str | None = None) -> dict[str, object]:
+def validate_semantic_version(version: str) -> bool:
+    """Validate that a version string follows semantic versioning (X.Y.Z or X.Y.Z-prerelease)."""
+    pattern = r'^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$'
+    return bool(re.match(pattern, version))
+
+
+def generate_manifest(
+    model_path: Path, 
+    runtime_version: str, 
+    *, 
+    name: str | None = None,
+    model_version: str | None = None,
+    description: str | None = None
+) -> dict[str, object]:
     """Return manifest data for *model_path*."""
     if name is None:
         name = model_path.stem
+    
+    # Validate semantic versions if provided
+    if model_version and not validate_semantic_version(model_version):
+        raise ValueError(f"Invalid model version '{model_version}'. Must follow semantic versioning (X.Y.Z)")
+    
+    if not validate_semantic_version(runtime_version):
+        raise ValueError(f"Invalid runtime version '{runtime_version}'. Must follow semantic versioning (X.Y.Z)")
+    
     size = model_path.stat().st_size
     with model_path.open("rb") as fh:
         digest = hashlib.file_digest(fh, "sha256").hexdigest()
-    return {
+    
+    manifest = {
         "name": name,
         "size": size,
         "sha256": digest,
         "runtime_version": runtime_version,
+        "created_at": datetime.utcnow().isoformat() + "Z",
     }
+    
+    # Add optional fields if provided
+    if model_version:
+        manifest["model_version"] = model_version
+    if description:
+        manifest["description"] = description
+    
+    return manifest
 
 
 def main(argv: list[str] | None = None) -> None:
-    parser = argparse.ArgumentParser(description="Generate manifest.json")
+    parser = argparse.ArgumentParser(
+        description="Generate manifest.json for a CoreML model",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  %(prog)s model.mlpackage manifest.json --runtime-version 1.0.0
+  %(prog)s model.mlpackage manifest.json --runtime-version 1.0.0 --model-version 2.1.0 --name "GPT-2 125M"
+        """.strip()
+    )
     parser.add_argument("model", type=Path, help="Path to .mlpackage")
     parser.add_argument("output", type=Path, help="Path to manifest.json")
-    parser.add_argument("--runtime-version", required=True, help="Runtime version")
+    parser.add_argument("--runtime-version", required=True, 
+                       help="Runtime version (must follow semantic versioning)")
     parser.add_argument("--name", help="Model display name")
+    parser.add_argument("--model-version", 
+                       help="Model version (must follow semantic versioning)")
+    parser.add_argument("--description", help="Model description")
     args = parser.parse_args(argv)
 
-    manifest = generate_manifest(
-        args.model, args.runtime_version, name=args.name
-    )
-    with args.output.open("w") as fh:
-        json.dump(manifest, fh, indent=2)
-        fh.write("\n")
+    try:
+        manifest = generate_manifest(
+            args.model, 
+            args.runtime_version, 
+            name=args.name,
+            model_version=args.model_version,
+            description=args.description
+        )
+        with args.output.open("w") as fh:
+            json.dump(manifest, fh, indent=2)
+            fh.write("\n")
+        print(f"Manifest generated: {args.output}")
+    except ValueError as e:
+        parser.error(str(e))
 
 
 if __name__ == "__main__":

--- a/Scripts/tests/test_manifest.py
+++ b/Scripts/tests/test_manifest.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 import json
 import hashlib
+import pytest
 import sys
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
@@ -11,11 +12,55 @@ import Scripts.manifest as manifest
 def test_generate_manifest(tmp_path: Path) -> None:
     file_path = tmp_path / "model.mlpackage"
     file_path.write_bytes(b"test")
-    data = manifest.generate_manifest(file_path, "1.0")
+    data = manifest.generate_manifest(file_path, "1.0.0")
     assert data["name"] == "model"
     assert data["size"] == 4
     assert data["sha256"] == hashlib.sha256(b"test").hexdigest()
-    assert data["runtime_version"] == "1.0"
+    assert data["runtime_version"] == "1.0.0"
+    assert "created_at" in data
+
+
+def test_generate_manifest_with_optional_fields(tmp_path: Path) -> None:
+    file_path = tmp_path / "model.mlpackage"
+    file_path.write_bytes(b"test")
+    data = manifest.generate_manifest(
+        file_path, 
+        "1.0.0",
+        name="Custom Model",
+        model_version="2.1.0",
+        description="A test model"
+    )
+    assert data["name"] == "Custom Model"
+    assert data["model_version"] == "2.1.0" 
+    assert data["description"] == "A test model"
+
+
+def test_semantic_version_validation() -> None:
+    # Valid versions
+    assert manifest.validate_semantic_version("1.0.0")
+    assert manifest.validate_semantic_version("1.2.3")
+    assert manifest.validate_semantic_version("1.0.0-alpha")
+    assert manifest.validate_semantic_version("1.0.0-alpha.1")
+    assert manifest.validate_semantic_version("1.0.0+build.1")
+    
+    # Invalid versions
+    assert not manifest.validate_semantic_version("1.0")
+    assert not manifest.validate_semantic_version("1")
+    assert not manifest.validate_semantic_version("1.0.0.0")
+    assert not manifest.validate_semantic_version("v1.0.0")
+
+
+def test_generate_manifest_invalid_versions(tmp_path: Path) -> None:
+    file_path = tmp_path / "model.mlpackage"
+    file_path.write_bytes(b"test")
+    
+    # Invalid runtime version
+    with pytest.raises(ValueError, match="Invalid runtime version"):
+        manifest.generate_manifest(file_path, "1.0")
+    
+    # Invalid model version
+    with pytest.raises(ValueError, match="Invalid model version"):
+        manifest.generate_manifest(file_path, "1.0.0", model_version="2.0")
 
 
 def test_manifest_main(tmp_path: Path) -> None:
@@ -26,10 +71,31 @@ def test_manifest_main(tmp_path: Path) -> None:
         str(model),
         str(out),
         "--runtime-version",
-        "2.0",
+        "2.0.0",
         "--name",
         "A",
     ])
     result = json.loads(out.read_text())
     assert result["name"] == "A"
-    assert result["runtime_version"] == "2.0"
+    assert result["runtime_version"] == "2.0.0"
+
+
+def test_manifest_main_with_all_options(tmp_path: Path) -> None:
+    model = tmp_path / "model.mlpackage"
+    model.write_text("test content")
+    out = tmp_path / "manifest.json"
+    manifest.main([
+        str(model),
+        str(out),
+        "--runtime-version", "1.2.0",
+        "--name", "Test Model",
+        "--model-version", "3.1.4", 
+        "--description", "A comprehensive test model"
+    ])
+    result = json.loads(out.read_text())
+    assert result["name"] == "Test Model"
+    assert result["runtime_version"] == "1.2.0"
+    assert result["model_version"] == "3.1.4"
+    assert result["description"] == "A comprehensive test model"
+    assert result["size"] == len("test content")
+    assert "created_at" in result


### PR DESCRIPTION
- Add semantic version validation for runtime and model versions
- Include optional model_version and description fields
- Add created_at timestamp to manifest metadata
- Improve CLI interface with better help and examples
- Enhance test coverage with comprehensive validation tests
- Mark task 1.2 complete in REVIEW_ACTION_PLAN.md

Implements task 1.2: Create manifest generator from the review action plan.